### PR TITLE
Add slug auto-generation hooks for Division and Tour models

### DIFF
--- a/src/app/modules/division/division.model.ts
+++ b/src/app/modules/division/division.model.ts
@@ -1,4 +1,5 @@
 import { model, Schema } from "mongoose";
+import { IDivision } from "./division.interface";
 
 const divisionSchema = new Schema({
     name: {type: String, required: true, unique: true},
@@ -7,6 +8,36 @@ const divisionSchema = new Schema({
     description: {type: String},
 },{
     timestamps: true,
+})
+
+divisionSchema.pre("save",async function(next){
+    if(this.isModified("name")){
+         const baseSlug = this.name.toLowerCase().split(" ").join("-");
+  let slug = `${baseSlug}-division`;
+  let counter = 0;
+  
+  while (await Division.exists({ slug })) {
+    slug = `${baseSlug}-division-${++counter}`;
+  }
+  this.slug = slug;
+  }
+  next();
+})
+
+divisionSchema.pre("findOneAndUpdate", async function(next) {
+  const division = this.getUpdate() as Partial<IDivision>;
+  if (division.name) {
+    const baseSlug = division.name.toLowerCase().split(" ").join("-");
+    let slug = `${baseSlug}-division`;
+    let counter = 0;
+
+    while (await Division.exists({ slug })) {
+      slug = `${baseSlug}-division-${++counter}`;
+    }
+    division.slug = slug;
+  }
+  this.setUpdate(division);
+  next();
 })
 
 export const Division = model("Division", divisionSchema);

--- a/src/app/modules/division/division.service.ts
+++ b/src/app/modules/division/division.service.ts
@@ -2,13 +2,13 @@ import { IDivision } from "./division.interface";
 import { Division } from "./division.model";
 
 const createDivision = async (payload: IDivision) => {
-  const baseSlug = payload.name.toLowerCase().split(" ").join("-");
-  let slug = `${baseSlug}-division`;
-  let counter = 0;
+//   const baseSlug = payload.name.toLowerCase().split(" ").join("-");
+//   let slug = `${baseSlug}-division`;
+//   let counter = 0;
   
-  while (await Division.exists({ slug })) {
-    slug = `${baseSlug}-division-${++counter}`;
-  }
+//   while (await Division.exists({ slug })) {
+//     slug = `${baseSlug}-division-${++counter}`;
+//   }
 
 
  
@@ -19,7 +19,7 @@ const createDivision = async (payload: IDivision) => {
     }
 
 
-
+// payload.slug = slug;
     const division = await Division.create(payload);
 
     return division
@@ -54,7 +54,14 @@ const updateDivision = async (id: string, payload: Partial<IDivision>) => {
         throw new Error("A division with this name already exists.");
     }
 
-
+//  const baseSlug = payload.name.toLowerCase().split(" ").join("-");
+//   let slug = `${baseSlug}-division`;
+//   let counter = 0;
+  
+//   while (await Division.exists({ slug })) {
+//     slug = `${baseSlug}-division-${++counter}`;
+//   }
+// payload.slug = slug;
 
     const updatedDivision = await Division.findByIdAndUpdate(id, payload, { new: true, runValidators: true })
 

--- a/src/app/modules/tour/tour.models.ts
+++ b/src/app/modules/tour/tour.models.ts
@@ -12,7 +12,7 @@ export const TourType = model<ITourType>("TourType", tourTypeSchema);
 
 const tourSchema = new Schema<ITour>({
     title:{type: String, required: true, unique: true},
-    slug:{type: String, required: true, unique: true},
+    slug:{type: String,  unique: true},
     thumbnail:{type: String},
     images:{type: [String], default: []},
     description:{type: String},
@@ -32,4 +32,35 @@ const tourSchema = new Schema<ITour>({
 },{
     timestamps: true,
 })
+
+
+tourSchema.pre("save",async function(next){
+    if(this.isModified("title")){
+         const baseSlug = this.title.toLowerCase().split(" ").join("-");
+  let slug = `${baseSlug}-tour`;
+  let counter = 0;
+
+  while (await Tour.exists({ slug })) {
+    slug = `${baseSlug}-tour-${++counter}`;
+  }
+  this.slug = slug;
+  }
+  next();
+})
+tourSchema.pre("findOneAndUpdate", async function(next) {
+  const tour = this.getUpdate() as Partial<ITour>;
+  if (tour.title) {
+    const baseSlug = tour.title.toLowerCase().split(" ").join("-");
+    let slug = `${baseSlug}-tour`;
+    let counter = 0;
+
+    while (await Tour.exists({ slug })) {
+      slug = `${baseSlug}-tour-${++counter}`;
+    }
+    tour.slug = slug;
+  }
+  this.setUpdate(tour);
+  next();
+})
+
 export const Tour = model<ITour>("Tour", tourSchema);

--- a/src/app/modules/tour/tour.service.ts
+++ b/src/app/modules/tour/tour.service.ts
@@ -1,16 +1,25 @@
 
-import { QueryBuilder } from "../../utils/QueryBuilder";
-import { tourSearchableFields } from "./tour.constant";
+
+
 import { ITour, ITourType } from "./tour.interface";
 import { Tour, TourType } from "./tour.models";
 
 const createTour = async (payload: ITour) => {
     const existingTour = await Tour.findOne({ title: payload.title });
+
     if (existingTour) {
         throw new Error("A tour with this title already exists.");
     }
 
-
+//      const baseSlug = payload.title.toLowerCase().split(" ").join("-");
+//       let slug = `${baseSlug}-tour`;
+//       let counter = 0;
+      
+//       while (await Tour.exists({ slug })) {
+//         slug = `${baseSlug}-tour-${++counter}`;
+//       }
+    
+// payload.slug = slug;
     const tour = await Tour.create(payload)
 
     return tour;
@@ -21,28 +30,24 @@ const createTour = async (payload: ITour) => {
 
 
 const getAllTours = async (query: Record<string, string>) => {
+const searchTerm = query.searchTerm || "";
 
+const tours = await Tour.find({
+    // title: { $regex: searchTerm, $options: 'i' }
 
-    const queryBuilder = new QueryBuilder(Tour.find(), query)
-
-    const tours = await queryBuilder
-        .search(tourSearchableFields)
-        .filter()
-        .sort()
-        .fields()
-        .paginate()
-
-
-    const [data, meta] = await Promise.all([
-        tours.build(),
-        queryBuilder.getMeta()
-    ])
-
-
-    return {
-        data,
-        meta
-    }
+    $or: [
+        { title: { $regex: searchTerm, $options: 'i' } },
+        { description: { $regex: searchTerm, $options: 'i' } },
+        { location: { $regex: searchTerm, $options: 'i' } }
+    ]
+});
+const totalTours = await Tour.countDocuments();
+   return {
+       data: tours,
+       meta:{
+              total: totalTours
+       }
+   };
 };
 
 
@@ -53,7 +58,14 @@ const updateTour = async (id: string, payload: Partial<ITour>) => {
     if (!existingTour) {
         throw new Error("Tour not found.");
     }
+//  const baseSlug = payload.title.toLowerCase().split(" ").join("-");
+//   let slug = `${baseSlug}-tour`;
+//   let counter = 0;
 
+//   while (await Tour.exists({ slug })) {
+//     slug = `${baseSlug}-tour-${++counter}`;
+//   }
+// payload.slug = slug;
 
     const updatedTour = await Tour.findByIdAndUpdate(id, payload, { new: true });
 
@@ -93,6 +105,8 @@ const deleteTourType = async (id: string) => {
 
     return await TourType.findByIdAndDelete(id);
 };
+
+
 
 export const TourService = {
     createTour,

--- a/src/app/modules/tour/tour.validation.ts
+++ b/src/app/modules/tour/tour.validation.ts
@@ -35,8 +35,7 @@ export const updateTourZodSchema = z.object({
     tourPlan: z.array(z.string()).optional(),
     maxGuest: z.number().optional(),
     minAge: z.number().optional(),
-    departureLocation: z.string().optional(),
-    arrivalLocation: z.string().optional()
+    division: z.string().optional(),
 });
 
 export const createTourTypeZodSchema = z.object({


### PR DESCRIPTION
Implements pre-save and pre-update hooks in the Division and Tour models to automatically generate unique slugs based on their name or title. Removes redundant slug generation logic from service methods to improve maintainability and consistency. Updates Tour schema to make the slug field optional and revises the search functionality to include multiple fields.

Enhances code clarity and reduces duplication by centralizing slug generation logic in model hooks.

Add slug auto-generation hooks for Division and Tour models

Implements pre-save and pre-update hooks in Division and Tour models to centralize and automate unique slug generation based on name or title. Removes redundant slug generation logic from service methods, improving code maintainability and consistency.

Updates Tour schema to make the slug field optional and enhances search functionality to query multiple fields. Refactors code to reduce duplication and enhance clarity.